### PR TITLE
feat(repo/github): add cname to oczadly.io

### DIFF
--- a/repositories/github/oczadly-io/main.tf
+++ b/repositories/github/oczadly-io/main.tf
@@ -13,6 +13,8 @@ resource "github_repository" "repo" {
   license_template = "mit"
 
   pages {
+    cname = "oczadly.io"
+
     source {
       branch = "gh-pages"
       path   = "/"


### PR DESCRIPTION
## 📝 Description

Add CNAME to gh-pages settings.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
