### PR TITLE
feat(repo/github): create gradle-springinitializr-plugin repository

### DIFF
--- a/repositories/github/gradle-springinitializr-plugin/main.tf
+++ b/repositories/github/gradle-springinitializr-plugin/main.tf
@@ -1,0 +1,29 @@
+resource "github_repository" "repo" {
+  name        = "gradle-springinitializr-plugin"
+  description = "Gradle plugin for bootstrapping Spring Boot projects using Spring Initializr. Production-ready with functional tests, build cache support, and idiomatic Gradle patterns."
+  visibility  = "private"
+
+  auto_init        = true
+  license_template = "mit"
+
+  delete_branch_on_merge = true
+
+  has_issues   = true
+  has_wiki     = false
+  has_projects = false
+}
+
+resource "github_branch" "branch_main" {
+  repository = github_repository.repo.name
+  branch     = "main"
+}
+
+resource "github_branch_default" "repo_default_branch" {
+  repository = github_repository.repo.name
+  branch     = github_branch.branch_main.branch
+}
+
+resource "github_actions_repository_permissions" "write_permissions" {
+  repository      = github_repository.repo.name
+  allowed_actions = "all"
+}

--- a/repositories/github/gradle-springinitializr-plugin/providers.tf
+++ b/repositories/github/gradle-springinitializr-plugin/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "paweloczadly"
+}


### PR DESCRIPTION
## 📝 Description

This PR creates [gradle-springinitializr-plugin](https://github.com/paweloczadly/gradle-springinitializr-plugin). It will be open source. It will be described on the blog.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
