### PR TITLE
feat(repo/github): publish gradle-springinitializr-plugin repository

### DIFF
--- a/repositories/github/gradle-springinitializr-plugin/main.tf
+++ b/repositories/github/gradle-springinitializr-plugin/main.tf
@@ -1,7 +1,7 @@
 resource "github_repository" "repo" {
   name        = "gradle-springinitializr-plugin"
   description = "Gradle plugin for bootstrapping Spring Boot projects using Spring Initializr. Production-ready with functional tests, build cache support, and idiomatic Gradle patterns."
-  visibility  = "private"
+  visibility  = "public"
 
   auto_init        = true
   license_template = "mit"
@@ -21,6 +21,20 @@ resource "github_branch" "branch_main" {
 resource "github_branch_default" "repo_default_branch" {
   repository = github_repository.repo.name
   branch     = github_branch.branch_main.branch
+}
+
+resource "github_branch_protection" "branch_protection_main" {
+  repository_id = github_repository.repo.id
+  pattern       = "main"
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = []
+    strict   = true
+  }
 }
 
 resource "github_actions_repository_permissions" "write_permissions" {


### PR DESCRIPTION
## 📝 Description

This PR publishes https://github.com/paweloczadly/gradle-springinitializr-plugin.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
