### PR TITLE
feat(dns): add gradle-verification TXT record

### DIFF
--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -28,3 +28,12 @@ resource "cloudflare_dns_record" "cname_www_oczadly_io" {
   content = "paweloczadly.github.io"
   ttl     = 60
 }
+
+resource "cloudflare_dns_record" "txt_gradle_verification" {
+  zone_id = var.cloudflare_zone_id
+  name    = "gradle-verification"
+  comment = "[OpenTofu/iac] Gradle Plugins verification"
+  type    = "TXT"
+  content = "\"gradle-verification=2DDLSGLSIMTFMOKOLOML252NTGKPG\""
+  ttl     = 60
+}


### PR DESCRIPTION
## 📝 Description

Adds DNS TXT record requested by the Gradle Team in the following email:

> Hi,
> 
> We received your plugin submission of "io.oczadly.springinitializr" for "io.oczadly" group.
> 
> Your plugin was flagged for manual review because of the following issue(s):
> 
> The group ID prefix 'io.oczadly' does not match the default GitHub domain for your username 'io.github.paweloczadly'. Please prove ownership of the "[oczadly.io](https://www.google.com/url?q=http://oczadly.io&sa=D&source=docs&ust=1756026337067471&usg=AOvVaw2kfdWXFG1qgqAS5YwsZmv9)" domain by adding a TXT record with the value "gradle-verification=2DDLSGLSIMTFMOKOLOML252NTGKPG" to your DNS, or use a plugin ID that ties to your GitHub user ID, for example 'io.github.paweloczadly.springinitializr'.
Please refer to our documentation on plugin approval guidelines for more information: [https://plugins.gradle.org/docs/publish-plugin#approval](https://www.google.com/url?q=https://plugins.gradle.org/docs/publish-plugin%23approval&sa=D&source=docs&ust=1756026337067655&usg=AOvVaw1N40ROzfjOIWrPwFKKcor4)
> 
> Please resubmit your plugin once you have corrected these issues to be reconsidered for approval. Your plugin submission has been canceled, so you may reuse the same version number.
> 
> Thanks!
> 
> Greetings,
> The Gradle Team
> [https://gradle.org](https://www.google.com/url?q=https://gradle.org&sa=D&source=docs&ust=1756026337067720&usg=AOvVaw2mSGIdsi22vuFg7_lGBGdx)

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
