### PR TITLE
feat(repo/github): create infra-at-scale/organization-template repository

### DIFF
--- a/repositories/github/infra-at-scale/organization-template/main.tf
+++ b/repositories/github/infra-at-scale/organization-template/main.tf
@@ -1,0 +1,44 @@
+resource "github_repository" "repo" {
+  name        = "organization-template"
+  description = "Opinionated yet minimal IaC structure using OpenTofu and AVM best practices."
+  visibility  = "public"
+
+  auto_init            = false
+  is_template          = true
+  vulnerability_alerts = true
+
+  delete_branch_on_merge = true
+
+  has_issues   = true
+  has_wiki     = false
+  has_projects = false
+}
+
+resource "github_branch" "branch_main" {
+  repository = github_repository.repo.name
+  branch     = "main"
+}
+
+resource "github_branch_default" "repo_default_branch" {
+  repository = github_repository.repo.name
+  branch     = github_branch.branch_main.branch
+}
+
+resource "github_branch_protection" "branch_protection_main" {
+  repository_id = github_repository.repo.id
+  pattern       = "main"
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = []
+    strict   = true
+  }
+}
+
+resource "github_actions_repository_permissions" "write_permissions" {
+  repository      = github_repository.repo.name
+  allowed_actions = "all"
+}

--- a/repositories/github/infra-at-scale/organization-template/providers.tf
+++ b/repositories/github/infra-at-scale/organization-template/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "infra-at-scale"
+}


### PR DESCRIPTION
## 📝 Description

Creates [infra-at-scale/organization-template](https://github.com/infra-at-scale/organization-template) GitHub repository. It's described in the first article of the "Infrastructure at scale with Azure and OpenTofu" series.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
