### PR TITLE
feat: add paweloczadly/talks repo with DNS record

### DIFF
--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -29,6 +29,15 @@ resource "cloudflare_dns_record" "cname_www_oczadly_io" {
   ttl     = 60
 }
 
+resource "cloudflare_dns_record" "cname_talks_oczadly_io" {
+  zone_id = var.cloudflare_zone_id
+  name    = "talks"
+  comment = "[OpenTofu/iac] GitHub CNAME record to paweloczadly.github.io"
+  type    = "CNAME"
+  content = "paweloczadly.github.io"
+  ttl     = 60
+}
+
 resource "cloudflare_dns_record" "txt_gradle_verification" {
   zone_id = var.cloudflare_zone_id
   name    = local.name_oczadly_io

--- a/repositories/github/paweloczadly/talks/main.tf
+++ b/repositories/github/paweloczadly/talks/main.tf
@@ -1,0 +1,41 @@
+resource "github_repository" "repo" {
+  name         = "talks"
+  description  = "Public speaking engagements of Paweł Oczadły."
+  visibility   = "public"
+  homepage_url = "https://talks.oczadly.io"
+
+  has_issues   = true
+  has_wiki     = false
+  has_projects = false
+
+  delete_branch_on_merge = true
+
+  template {
+    owner                = "paweloczadly"
+    repository           = "blog-template"
+    include_all_branches = true
+  }
+
+  lifecycle {
+    ignore_changes = [pages]
+  }
+}
+
+resource "github_branch_protection" "branch_protection_main" {
+  repository_id = github_repository.repo.id
+  pattern       = "main"
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = []
+    strict   = true
+  }
+}
+
+resource "github_actions_repository_permissions" "write_permissions" {
+  repository      = github_repository.repo.name
+  allowed_actions = "all"
+}

--- a/repositories/github/paweloczadly/talks/providers.tf
+++ b/repositories/github/paweloczadly/talks/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "paweloczadly"
+}


### PR DESCRIPTION
## 📝 Description

Adds paweloczadly/talks GitHub repository with talks.oczadly.io DNS record.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
